### PR TITLE
Minor bugfixes for tigrLine/tigrRect

### DIFF
--- a/src/tigr_bitmaps.c
+++ b/src/tigr_bitmaps.c
@@ -206,15 +206,22 @@ void tigrFillRect(Tigr* bmp, int x, int y, int w, int h, TPixel color) {
 
 void tigrRect(Tigr* bmp, int x, int y, int w, int h, TPixel color) {
     int x1, y1;
-    if (w <= 0 || h <= 0)
+    if (w <= 0 || h <= 0) {
         return;
-
-    x1 = x + w - 1;
-    y1 = y + h - 1;
-    tigrLine(bmp, x, y, x1, y, color);
-    tigrLine(bmp, x1, y, x1, y1, color);
-    tigrLine(bmp, x1, y1, x, y1, color);
-    tigrLine(bmp, x, y1, x, y, color);
+    } else if (w == 1 && h != 1) {
+        tigrLine(bmp, x, y - h + 1, x, y + h - 1, color);
+    } else if (w != 1 && h == 1) {
+        tigrLine(bmp, x - w + 1, y, x + w - 1, y, color);
+    } else if (w == 1 && h == 1) {
+        tigrPlot(bmp, x, y, color);
+    } else {
+        x1 = x + w - 1;
+        y1 = y + h - 1;
+        tigrLine(bmp, x, y, x1, y, color);
+        tigrLine(bmp, x1, y, x1, y1, color);
+        tigrLine(bmp, x1, y1, x, y1, color);
+        tigrLine(bmp, x, y1, x, y, color);
+    }
 }
 
 void tigrFillCircle(Tigr* bmp, int x0, int y0, int r, TPixel color) {

--- a/tigr.c
+++ b/tigr.c
@@ -456,15 +456,22 @@ void tigrFillRect(Tigr* bmp, int x, int y, int w, int h, TPixel color) {
 
 void tigrRect(Tigr* bmp, int x, int y, int w, int h, TPixel color) {
     int x1, y1;
-    if (w <= 0 || h <= 0)
+    if (w <= 0 || h <= 0) {
         return;
-
-    x1 = x + w - 1;
-    y1 = y + h - 1;
-    tigrLine(bmp, x, y, x1, y, color);
-    tigrLine(bmp, x1, y, x1, y1, color);
-    tigrLine(bmp, x1, y1, x, y1, color);
-    tigrLine(bmp, x, y1, x, y, color);
+    } else if (w == 1 && h != 1) {
+        tigrLine(bmp, x, y - h + 1, x, y + h - 1, color);
+    } else if (w != 1 && h == 1) {
+        tigrLine(bmp, x - w + 1, y, x + w - 1, y, color);
+    } else if (w == 1 && h == 1) {
+        tigrPlot(bmp, x, y, color);
+    } else {
+        x1 = x + w - 1;
+        y1 = y + h - 1;
+        tigrLine(bmp, x, y, x1, y, color);
+        tigrLine(bmp, x1, y, x1, y1, color);
+        tigrLine(bmp, x1, y1, x, y1, color);
+        tigrLine(bmp, x, y1, x, y, color);
+    }
 }
 
 void tigrFillCircle(Tigr* bmp, int x0, int y0, int r, TPixel color) {

--- a/tigr.h
+++ b/tigr.h
@@ -124,7 +124,7 @@ void tigrClear(Tigr *bmp, TPixel color);
 void tigrFill(Tigr *bmp, int x, int y, int w, int h, TPixel color);
 
 // Draws a line.
-// Start and end pixels are drawn.
+// Start pixel is drawn, end pixel is not drawn.
 // Clips and blends.
 void tigrLine(Tigr *bmp, int x0, int y0, int x1, int y1, TPixel color);
 


### PR DESCRIPTION
I noticed the comment for tigrLine in the header was incorrect. The endpoint of the line is *not* drawn, despite saying it was. Then I noticed the tigrRect function overdraws the corners and doesn't handle the case of w or h being 1 properly. The comment for tigrRect says calling with (1,1) should behave the same as tigrPlot, which isn't the case due to overdraw.