### PR TITLE
Fix `objc_msgSend` in `_showPools`.

### DIFF
--- a/tigr.c
+++ b/tigr.c
@@ -2944,7 +2944,7 @@ static id autoreleasePool = NULL;
 #ifdef DEBUG
 static void _showPools(const char* context) {
     fprintf(stderr, "NSAutoreleasePool@%s:\n", context);
-    objc_msgSend(class("NSAutoreleasePool"), sel("showPools"));
+    ((id (*)(id, SEL))objc_msgSend)(class("NSAutoreleasePool"), sel("showPools"));
 }
 #define showPools(x) _showPools((x))
 #else


### PR DESCRIPTION
As I stated in https://github.com/erkkah/tigr/issues/24#issuecomment-1858700425, I guess you missed the `objc_msgSend` in `_showPools`. 

With this fix, It might be possible to remove the need of defining `OBJC_OLD_DISPATCH_PROTOTYPES` (in my case, it never worked).