### PR TITLE
fix: don't define 'tigrCalcScale' in headless mode

### DIFF
--- a/src/tigr_bitmaps.c
+++ b/src/tigr_bitmaps.c
@@ -70,6 +70,7 @@ void tigrResize(Tigr* bmp, int w, int h) {
     bmp->h = h;
 }
 
+#ifndef TIGR_HEADLESS
 int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH) {
     if (bmpW == 0 || bmpH == 0) {
         tigrError(0, "Invalid bitmap size, (%dx%d)", bmpW, bmpH);
@@ -87,6 +88,7 @@ int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH) {
     }
     return (scale > 1) ? scale : 1;
 }
+#endif // TIGR_HEADLESS
 
 int tigrEnforceScale(int scale, int flags) {
     if ((flags & TIGR_4X) && scale < 4)

--- a/src/tigr_internal.h
+++ b/src/tigr_internal.h
@@ -7,6 +7,9 @@
 // Graphics configuration.
 #ifndef TIGR_HEADLESS
 #define TIGR_GAPI_GL
+
+// Calculates the biggest scale that a bitmap can fit into an area at.
+int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH);
 #endif
 
 // Creates a new bitmap, with extra payload bytes.
@@ -14,9 +17,6 @@ Tigr* tigrBitmap2(int w, int h, int extra);
 
 // Resizes an existing bitmap.
 void tigrResize(Tigr* bmp, int w, int h);
-
-// Calculates the biggest scale that a bitmap can fit into an area at.
-int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH);
 
 // Calculates a new scale, taking minimum-scale flags into account.
 int tigrEnforceScale(int scale, int flags);

--- a/tigr.c
+++ b/tigr.c
@@ -14,6 +14,9 @@
 // Graphics configuration.
 #ifndef TIGR_HEADLESS
 #define TIGR_GAPI_GL
+
+// Calculates the biggest scale that a bitmap can fit into an area at.
+int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH);
 #endif
 
 // Creates a new bitmap, with extra payload bytes.
@@ -21,9 +24,6 @@ Tigr* tigrBitmap2(int w, int h, int extra);
 
 // Resizes an existing bitmap.
 void tigrResize(Tigr* bmp, int w, int h);
-
-// Calculates the biggest scale that a bitmap can fit into an area at.
-int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH);
 
 // Calculates a new scale, taking minimum-scale flags into account.
 int tigrEnforceScale(int scale, int flags);
@@ -326,6 +326,7 @@ void tigrResize(Tigr* bmp, int w, int h) {
     bmp->h = h;
 }
 
+#ifndef TIGR_HEADLESS
 int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH) {
     if (bmpW == 0 || bmpH == 0) {
         tigrError(0, "Invalid bitmap size, (%dx%d)", bmpW, bmpH);
@@ -343,6 +344,7 @@ int tigrCalcScale(int bmpW, int bmpH, int areaW, int areaH) {
     }
     return (scale > 1) ? scale : 1;
 }
+#endif // TIGR_HEADLESS
 
 int tigrEnforceScale(int scale, int flags) {
     if ((flags & TIGR_4X) && scale < 4)


### PR DESCRIPTION
Hi, while testing tigr's headless-mode, I've stumbled upon an issue:
The check for invalid bitmap-sizes in `tigrCalcScale` calls `tigrError`, which is not implemented in headless-mode.

This PR simply wraps `tigrCalcScale` inside of a `#ifndef TIGR_HEADLESS`.
When using headless-mode this function is used nowhere, thus I think that it's fine to "ignore" the implementation.
Also, the implementation is still there, so if somebody needed this function, they could just copy it and implement `tigrError` themselves.

